### PR TITLE
Fix merge segments and keep segments with disabled auto merge

### DIFF
--- a/src/main/java/ctbrec/recorder/LocalRecorder.java
+++ b/src/main/java/ctbrec/recorder/LocalRecorder.java
@@ -337,7 +337,7 @@ public class LocalRecorder implements Recorder {
                     }
                 }
                 LOG.debug("Keep segments: {}", Config.getInstance().getSettings().automergeKeepSegments);
-                if (!Config.getInstance().getSettings().automergeKeepSegments) {
+                if (Config.getInstance().getSettings().automerge && !Config.getInstance().getSettings().automergeKeepSegments) {
                     try {
                         LOG.debug("Deleting directory {}", recDir);
                         delete(recDir, mergedFile);


### PR DESCRIPTION
Disabled AutomergeKeepSegments will result in an automatic deletion of the files, so even when the user clicks "keep segments", they will be removed by the automergeKeepSegments flag